### PR TITLE
Remove background color from overlay

### DIFF
--- a/dist/css/govlab-styleguide.css
+++ b/dist/css/govlab-styleguide.css
@@ -4578,7 +4578,6 @@ Styleguide 1.2
   right: 0;
   z-index: 10;
   display: none;
-  background-color: red;
   opacity: .1; }
   #overlay.m-active {
     display: block; }

--- a/guide/styles/styles.css
+++ b/guide/styles/styles.css
@@ -4578,7 +4578,6 @@ Styleguide 1.2
   right: 0;
   z-index: 10;
   display: none;
-  background-color: red;
   opacity: .1; }
   #overlay.m-active {
     display: block; }

--- a/sass/components/_aux.scss
+++ b/sass/components/_aux.scss
@@ -6,8 +6,7 @@
     right: 0;
     z-index: 10;
     display: none;
-background-color: red;
-opacity: .1;
+    opacity: .1;
 
     &.m-active { display: block; } 
 }


### PR DESCRIPTION
Fixes #55 

I removed the background color for now, but can modify color/opacity later if we want.
